### PR TITLE
Add `--stable` flag and use GradleUtils

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,9 +37,7 @@ pipeline {
                     sh './gradlew ${GRADLE_ARGS} --refresh-dependencies --continue build test'
                 }
                 script {
-                    env.MYGROUP = sh(returnStdout: true, script: './gradlew properties -q | grep "group:" | awk \'{print $2}\'').trim()
-                    env.MYARTIFACT = sh(returnStdout: true, script: './gradlew properties -q | grep "archivesBaseName:" | awk \'{print $2}\'').trim()
-                    env.MYVERSION = sh(returnStdout: true, script: './gradlew properties -q | grep "version:" | awk \'{print $2}\'').trim()
+                    gradleVersion(this)
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -3,37 +3,37 @@ buildscript {
         maven {
             url 'https://plugins.gradle.org/m2/'
         }
+        maven { url = 'https://maven.minecraftforge.net' }
     }
     dependencies {
         classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.3'
+        classpath 'net.minecraftforge:GradleUtils:1.+'
     }
-}
-
-plugins {
-    id 'org.ajoberstar.grgit' version '4.1.0'
 }
 
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'com.github.johnrengelman.shadow'
+apply plugin: 'net.minecraftforge.gradleutils'
 
 sourceCompatibility = javaVersion
 targetCompatibility = javaVersion
 
 group = 'net.minecraftforge.lex' // Repackaged from 'org.cadixdev' to publish on Forge's Maven with out transformers
 archivesBaseName = project.name.toLowerCase()
-version = (grgit.describe(longDescr: true, tags: true) ?: 'unknown-unknown-unknown').split('-').with { "${it[0]}.${it[1]}" }
+version = gradleutils.getTagOffsetVersion()
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    compile "org.cadixdev:atlas:$atlasVersion"
-    compile "org.cadixdev:lorenz:$lorenzVersion"
-    compile "org.cadixdev:lorenz-asm:$lorenzVersion"
-    compile 'net.sf.jopt-simple:jopt-simple:5.0.4'
-    compile 'org.ow2.asm:asm-commons:9.1'
+    implementation "org.cadixdev:atlas:$atlasVersion"
+    implementation "org.cadixdev:lorenz:$lorenzVersion"
+    implementation "org.cadixdev:lorenz-asm:$lorenzVersion"
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
+    implementation 'org.ow2.asm:asm-commons:9.1'
+    implementation 'com.google.jimfs:jimfs:1.2'
 }
 
 processResources {

--- a/src/main/java/org/cadixdev/vignette/VignetteMain.java
+++ b/src/main/java/org/cadixdev/vignette/VignetteMain.java
@@ -159,20 +159,20 @@ public final class VignetteMain {
                     System.out.println("Parameter Annotations");
                 }
 
-                try (FileSystem memFs = Jimfs.newFileSystem(Configuration.unix())) {
-                    Path memoryOutput = memFs.getPath("output.jar");
+                if (options.has(stableSpec)) {
+                    try (FileSystem memFs = Jimfs.newFileSystem(Configuration.unix())) {
+                        Path memoryOutput = memFs.getPath("output.jar");
 
-                    try {
-                        atlas.run(jarInPath, memoryOutput);
-                    } catch (UnsupportedOperationException e) {
-                        // dumb software
+                        try {
+                            atlas.run(jarInPath, memoryOutput);
+                        } catch (UnsupportedOperationException e) {
+                            // TODO upstream a fix to Atlas
+                        }
+
+                        Files.copy(makeStableJar(memFs, memoryOutput), jarOutPath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
                     }
-
-                    if (options.has(stableSpec)) {
-                        memoryOutput = makeStableJar(memFs, memoryOutput);
-                    }
-
-                    Files.copy(memoryOutput, jarOutPath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
+                } else {
+                    atlas.run(jarInPath, jarOutPath);
                 }
 
                 System.out.println("Processing Complete");


### PR DESCRIPTION
This PR adds a stable flag which attempts to make output jars more consistent for the same inputs. Jars now have their entries sorted by name with this flag enabled, and the timestamps of every zip entry is made the same including directories. GradleUtils is now used for git stuff, and the Jenkinsfile has a slight update.